### PR TITLE
Correct types

### DIFF
--- a/command.js
+++ b/command.js
@@ -811,7 +811,6 @@ registerPlugin({
     _refreshTimeout(id) {
       if (this._throttled[id] === undefined) return
       clearTimeout(this._throttled[id].timeout)
-      // @ts-ignore
       this._throttled[id].timeout = setTimeout(this._restorePoints.bind(this, id), this._tickrate)
       this._throttled[id].next = Date.now() + this._tickrate
     }

--- a/command.js
+++ b/command.js
@@ -1,4 +1,3 @@
-///<reference path="./node_modules/sinusbot-scripting-engine/tsd/types.d.ts" />
 registerPlugin({
   name: "Command",
   description: "Library to handle and manage commands",
@@ -84,16 +83,7 @@ registerPlugin({
    * @property {Client} client the client which invoked the command
    * @property {Record<string, any>} arguments arguments from the command
    * @property {Message} raw raw message
-   * @property {DiscordMessage?} message
-   */
-
-  /**
-   * callback for the command event
-   * @callback execHandler
-   * @param {Client} invoker
-   * @param {Record<string, any>} args
-   * @param {(msg: string) => void} reply
-   * @param {Message} event
+   * @property {DiscordMessage} [message]
    */
 
   /**
@@ -104,7 +94,16 @@ registerPlugin({
    * @property {Channel} channel
    * @property {string} text
    * @property {number} mode
-   * @property {DiscordMessage?} message
+   * @property {DiscordMessage} [message]
+   */
+
+  /**
+   * callback for the command event
+   * @callback execHandler
+   * @param {Client} invoker
+   * @param {Record<string, any>} args
+   * @param {(msg: string) => void} reply
+   * @param {MessageEvent} event
    */
 
   /**
@@ -812,6 +811,7 @@ registerPlugin({
     _refreshTimeout(id) {
       if (this._throttled[id] === undefined) return
       clearTimeout(this._throttled[id].timeout)
+      // @ts-ignore
       this._throttled[id].timeout = setTimeout(this._restorePoints.bind(this, id), this._tickrate)
       this._throttled[id].next = Date.now() + this._tickrate
     }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,8 +2,10 @@
     "compilerOptions": {
         "checkJs": true,
         "strict": true,
-        "target": "es2018"
+        "target": "es2018",
+        "types" : ["sinusbot-scripting-engine"]
     },
+    "typeAcquisition": {"enable": false},
     "exclude": [
         "node_modules",
         "**/node_modules/*"


### PR DESCRIPTION
This fixes two things:

1. execHandler now correctly states that event has the optional message property
2. typeAcquisition is now limited to "sinusbot-scripting-engine", this means:
  - you don't need to include the `///<reference path...`
  - it will not use NodeJS Types
  - it works regardless of whether you have enabled typeAcquisition globally or not. Previously I would get erros from NodeJS but that is not the case anymore with this change.